### PR TITLE
Fixed link to contributing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ console.log(hasAttr('something', JSON));
 
 We are constantly working on improving `hasattr` and we need all the help we can get. 
 
-You can contribute to this project by giving [suggestions](https://github.com/arshadkazmi42/hasattr/issues/new), fixing [open issues](https://github.com/arshadkazmi42/hasattr/issues) or by implementing a new feature. Read our contibution guide [here](https://github.com/arshadkazmi42/hasattr/CONTRIBUTING.md)
+You can contribute to this project by giving [suggestions](https://github.com/arshadkazmi42/hasattr/issues/new), fixing [open issues](https://github.com/arshadkazmi42/hasattr/issues) or by implementing a new feature. Read our contibution guide [here](CONTRIBUTING.md)


### PR DESCRIPTION
Fixes #8 
-

Now the link to contributing page can open the correct page :)

<img width="1062" alt="screen shot 2019-02-27 at 10 41 02 am" src="https://user-images.githubusercontent.com/14871820/53454790-741e2880-3a7c-11e9-90f4-0b27a1cc0ceb.png">

